### PR TITLE
[DEV-3130, DEV-3131] Add GitHub workflow triggers for guide and solution list pages after update

### DIFF
--- a/.changeset/clear-animals-punch.md
+++ b/.changeset/clear-animals-punch.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Add workflow trigger on guide list pages and soluzion list page

--- a/apps/strapi-cms/src/api/guide-list-page/content-types/guide-list-page/lifecycles.ts
+++ b/apps/strapi-cms/src/api/guide-list-page/content-types/guide-list-page/lifecycles.ts
@@ -15,12 +15,12 @@ module.exports = {
   async afterUpdate(event: IEventWithProduct) {
       if (event.params.data.publishedAt === undefined) {
         console.log(
-          'Release note not published, skipping GitHub workflow trigger'
+          'GuideListPage not published, skipping GitHub workflow trigger'
         );
         return;
       }
   
-      console.log('Release note updated, triggering GitHub workflow...');
+      console.log('GuideListPage updated, triggering GitHub workflow...');
       // Fire and forget - don't block the UI
       triggerGithubWorkflow('guides').catch(error => 
         console.error('Failed to trigger workflow after update:', error)

--- a/apps/strapi-cms/src/api/guide-list-page/content-types/guide-list-page/lifecycles.ts
+++ b/apps/strapi-cms/src/api/guide-list-page/content-types/guide-list-page/lifecycles.ts
@@ -1,3 +1,4 @@
+import { triggerGithubWorkflow } from '../../../../utils/triggerGithubWorkflow';
 import {
   IEventWithProduct,
   validateAssociatedProductPresenceOnCreate,
@@ -11,4 +12,18 @@ module.exports = {
   beforeUpdate(event: IEventWithProduct) {
     validateAssociatedProductPresenceOnUpdate(event);
   },
+  async afterUpdate(event: IEventWithProduct) {
+      if (event.params.data.publishedAt === undefined) {
+        console.log(
+          'Release note not published, skipping GitHub workflow trigger'
+        );
+        return;
+      }
+  
+      console.log('Release note updated, triggering GitHub workflow...');
+      // Fire and forget - don't block the UI
+      triggerGithubWorkflow('guides').catch(error => 
+        console.error('Failed to trigger workflow after update:', error)
+      );
+    },
 };

--- a/apps/strapi-cms/src/api/solution-list-page/content-types/solution-list-page/lifecycles.ts
+++ b/apps/strapi-cms/src/api/solution-list-page/content-types/solution-list-page/lifecycles.ts
@@ -8,12 +8,12 @@ module.exports = {
   async afterUpdate(event: IEventWithProduct) {
     if (event.params.data.publishedAt === undefined) {
       console.log(
-        'Release note not published, skipping GitHub workflow trigger'
+        'SolutionListPage not published, skipping GitHub workflow trigger'
       );
       return;
     }
 
-    console.log('Release note updated, triggering GitHub workflow...');
+    console.log('SolutionListPage updated, triggering GitHub workflow...');
     // Fire and forget - don't block the UI
     triggerGithubWorkflow('solutions').catch(error => 
       console.error('Failed to trigger workflow after update:', error)

--- a/apps/strapi-cms/src/api/solution-list-page/content-types/solution-list-page/lifecycles.ts
+++ b/apps/strapi-cms/src/api/solution-list-page/content-types/solution-list-page/lifecycles.ts
@@ -1,0 +1,22 @@
+import {
+  IEventWithProduct,
+} from '../../../../utils/validateProductPresence';
+import { triggerGithubWorkflow } from '../../../../utils/triggerGithubWorkflow';
+
+
+module.exports = {
+  async afterUpdate(event: IEventWithProduct) {
+    if (event.params.data.publishedAt === undefined) {
+      console.log(
+        'Release note not published, skipping GitHub workflow trigger'
+      );
+      return;
+    }
+
+    console.log('Release note updated, triggering GitHub workflow...');
+    // Fire and forget - don't block the UI
+    triggerGithubWorkflow('solutions').catch(error => 
+      console.error('Failed to trigger workflow after update:', error)
+    );
+  },
+};


### PR DESCRIPTION
…updates

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Triggers sync workflow after updating published guide list pages and solution list pages

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
