### PR TITLE
[DEV-3991] Fix to double webinar generation

### DIFF
--- a/.changeset/every-mirrors-joke.md
+++ b/.changeset/every-mirrors-joke.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Remove second next() call when webinars are created

--- a/apps/strapi-cms/src/api/webinar/content-types/webinar/schema.json
+++ b/apps/strapi-cms/src/api/webinar/content-types/webinar/schema.json
@@ -27,16 +27,16 @@
     },
     "coverImage": {
       "type": "media",
-      "multiple": false,
-      "required": true,
-      "allowedTypes": [
-        "images"
-      ],
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      }
+      },
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images"
+      ]
     },
     "slug": {
       "type": "string",
@@ -46,8 +46,8 @@
         }
       },
       "required": true,
-      "regex": "^[a-zA-Z0-9-]+$",
-      "unique": true
+      "unique": true,
+      "regex": "^[a-zA-Z0-9-]+$"
     },
     "bodyContent": {
       "type": "blocks",
@@ -67,13 +67,13 @@
     },
     "videoOnDemandStartAt": {
       "type": "integer",
-      "default": 0,
-      "min": 0,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      }
+      },
+      "default": 0,
+      "min": 0
     },
     "startDatetime": {
       "type": "datetime",
@@ -108,13 +108,13 @@
     },
     "relatedLinks": {
       "type": "component",
-      "repeatable": false,
-      "component": "common.related-links",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      }
+      },
+      "component": "common.related-links",
+      "repeatable": false
     },
     "subscribeParagraphLabel": {
       "type": "string",
@@ -125,12 +125,12 @@
       }
     },
     "description": {
+      "type": "text",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "type": "text",
       "required": true
     },
     "solutions": {
@@ -141,33 +141,33 @@
     },
     "questionsAndAnswers": {
       "type": "component",
-      "repeatable": true,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "component": "common.question-and-answer"
+      "component": "common.question-and-answer",
+      "repeatable": true
     },
     "relatedResources": {
       "type": "component",
-      "repeatable": false,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "component": "webinar.related-resources"
+      "component": "webinar.related-resources",
+      "repeatable": false
     },
     "seo": {
       "type": "component",
-      "repeatable": false,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "component": "shared.seo"
+      "component": "shared.seo",
+      "repeatable": false
     },
     "webinarCategory": {
       "type": "relation",
@@ -176,39 +176,39 @@
     },
     "headerImage": {
       "type": "media",
-      "multiple": false,
-      "required": false,
-      "allowedTypes": [
-        "images"
-      ],
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      }
-    },
-    "playerCoverImage": {
-      "type": "media",
-      "multiple": false,
-      "required": false,
-      "allowedTypes": [
-        "images"
-      ],
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      }
-    },
-    "chapters": {
-      "type": "component",
-      "repeatable": true,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "component": "webinar.chapter"
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images"
+      ]
+    },
+    "playerCoverImage": {
+      "type": "media",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images"
+      ]
+    },
+    "chapters": {
+      "type": "component",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "webinar.chapter",
+      "repeatable": true
     }
   }
 }

--- a/apps/strapi-cms/src/api/webinar/content-types/webinar/schema.json
+++ b/apps/strapi-cms/src/api/webinar/content-types/webinar/schema.json
@@ -27,16 +27,16 @@
     },
     "coverImage": {
       "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": [
+        "images"
+      ],
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      },
-      "multiple": false,
-      "required": false,
-      "allowedTypes": [
-        "images"
-      ]
+      }
     },
     "slug": {
       "type": "string",
@@ -46,8 +46,8 @@
         }
       },
       "required": true,
-      "unique": true,
-      "regex": "^[a-zA-Z0-9-]+$"
+      "regex": "^[a-zA-Z0-9-]+$",
+      "unique": true
     },
     "bodyContent": {
       "type": "blocks",
@@ -67,13 +67,13 @@
     },
     "videoOnDemandStartAt": {
       "type": "integer",
+      "default": 0,
+      "min": 0,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      },
-      "default": 0,
-      "min": 0
+      }
     },
     "startDatetime": {
       "type": "datetime",
@@ -108,13 +108,13 @@
     },
     "relatedLinks": {
       "type": "component",
+      "repeatable": false,
+      "component": "common.related-links",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      },
-      "component": "common.related-links",
-      "repeatable": false
+      }
     },
     "subscribeParagraphLabel": {
       "type": "string",
@@ -125,12 +125,12 @@
       }
     },
     "description": {
-      "type": "text",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
+      "type": "text",
       "required": true
     },
     "solutions": {
@@ -141,33 +141,33 @@
     },
     "questionsAndAnswers": {
       "type": "component",
+      "repeatable": true,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "component": "common.question-and-answer",
-      "repeatable": true
+      "component": "common.question-and-answer"
     },
     "relatedResources": {
       "type": "component",
+      "repeatable": false,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "component": "webinar.related-resources",
-      "repeatable": false
+      "component": "webinar.related-resources"
     },
     "seo": {
       "type": "component",
+      "repeatable": false,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "component": "shared.seo",
-      "repeatable": false
+      "component": "shared.seo"
     },
     "webinarCategory": {
       "type": "relation",
@@ -176,39 +176,39 @@
     },
     "headerImage": {
       "type": "media",
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
       "multiple": false,
       "required": false,
       "allowedTypes": [
         "images"
-      ]
+      ],
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "playerCoverImage": {
       "type": "media",
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
       "multiple": false,
       "required": false,
       "allowedTypes": [
         "images"
-      ]
+      ],
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "chapters": {
       "type": "component",
+      "repeatable": true,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "component": "webinar.chapter",
-      "repeatable": true
+      "component": "webinar.chapter"
     }
   }
 }

--- a/apps/strapi-cms/src/index.ts
+++ b/apps/strapi-cms/src/index.ts
@@ -75,7 +75,6 @@ export default {
       if (context.uid === 'api::webinar.webinar' && context.action === 'create') {
         await createActiveCampaignList({
           params: context.params,
-          result: await next(),
         });
       }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Remove the second invocation of next() when creating the activecampaign list
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
this next() invocation created a webinar, followed by the next() invocation called at the end of the strapi.documtent.use
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
on localhost
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
