### PR TITLE
[DEV-3597] Add quickstart validation

### DIFF
--- a/.changeset/honest-humans-tickle.md
+++ b/.changeset/honest-humans-tickle.md
@@ -2,4 +2,4 @@
 "strapi-cms": patch
 ---
 
-Add validation to quickstart
+Require quickstart guides to have at least one quickstart guide item during create, update, and publish validation

--- a/.changeset/honest-humans-tickle.md
+++ b/.changeset/honest-humans-tickle.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Add validation to quickstart

--- a/apps/strapi-cms/src/index.ts
+++ b/apps/strapi-cms/src/index.ts
@@ -15,6 +15,10 @@ import {
 import {validateWebinarDates} from './utils/validateWebinarDates';
 import {validateSlugBeforeCreate, validateSlugBeforeUpdate} from './utils/validateWebinarSlug';
 import {createActiveCampaignList, deleteActiveCampaignList, preventBulkDeletion} from './utils/activeCampaignWebinar';
+import {
+  validateQuickstartGuideItemsPresenceOnCreate,
+  validateQuickstartGuideItemsPresenceOnUpdate
+} from "./utils/validateQuickstartGuide";
 
 export default {
 // @ts-ignore
@@ -78,6 +82,13 @@ export default {
         });
       }
 
+      if (context.uid === 'api::quickstart-guide.quickstart-guide'){
+        if(context.action === 'create') {
+          validateQuickstartGuideItemsPresenceOnCreate(context)
+        }
+        else if (context.action === 'update') {
+        await validateQuickstartGuideItemsPresenceOnUpdate(context);
+      }}
       return next();
     });
   },

--- a/apps/strapi-cms/src/index.ts
+++ b/apps/strapi-cms/src/index.ts
@@ -86,9 +86,10 @@ export default {
         if(context.action === 'create') {
           validateQuickstartGuideItemsPresenceOnCreate(context)
         }
-        else if (context.action === 'update') {
-        await validateQuickstartGuideItemsPresenceOnUpdate(context);
-      }}
+        else if (context.action === 'update' || context.action === 'publish') {
+          await validateQuickstartGuideItemsPresenceOnUpdate(context);
+        }
+      }
       return next();
     });
   },

--- a/apps/strapi-cms/src/utils/validateQuickstartGuide.ts
+++ b/apps/strapi-cms/src/utils/validateQuickstartGuide.ts
@@ -10,6 +10,7 @@ export interface IQuickstartGuideEvent {
       };
     };
     readonly documentId?: string;
+    readonly locale?: string;
   };
 }
 
@@ -31,7 +32,8 @@ export const validateQuickstartGuideItemsPresenceOnCreate = (event: IQuickstartG
 };
 
 export const validateQuickstartGuideItemsPresenceOnUpdate = async (event: IQuickstartGuideEvent) => {
-  const documentId = event.params.data.documentId || event.params.documentId;
+  const documentId = event.params.data?.documentId || event.params.documentId;
+  const locale = event.params.locale;
 
   if (!documentId) {
     throw new errors.ApplicationError('QuickstartGuide documentId not found');
@@ -48,7 +50,7 @@ export const validateQuickstartGuideItemsPresenceOnUpdate = async (event: IQuick
     throw new errors.ApplicationError('QuickstartGuide not found');
   }
 
-  const items = event.params.data.quickstartGuideItems;
+  const items = event.params.data?.quickstartGuideItems;
   const connectLength = items?.connect?.length || 0;
   const disconnectLength = items?.disconnect?.length || 0;
   const currentLength = foundQuickstartGuide.quickstartGuideItems?.length || 0;

--- a/apps/strapi-cms/src/utils/validateQuickstartGuide.ts
+++ b/apps/strapi-cms/src/utils/validateQuickstartGuide.ts
@@ -1,19 +1,19 @@
-import {errors} from "@strapi/utils";
+import { errors } from "@strapi/utils";
 
 export interface IQuickstartGuideEvent {
   readonly params: {
     readonly data: {
       readonly documentId?: string;
       readonly quickstartGuideItems?: {
-        readonly connect?: IQuickstartGuideItemsEvent[]
-        readonly disconnect?: IQuickstartGuideItemsEvent[]
-      }
-    }
+        readonly connect?: IQuickstartGuideItemsEvent[];
+        readonly disconnect?: IQuickstartGuideItemsEvent[];
+      };
+    };
     readonly documentId?: string;
-  }
+  };
 }
 
-interface IQuickstartGuideItemsEvent {
+export interface IQuickstartGuideItemsEvent {
   readonly id?: string;
   readonly documentId?: string;
   readonly locale?: string;
@@ -21,35 +21,43 @@ interface IQuickstartGuideItemsEvent {
 }
 
 export const validateQuickstartGuideItemsPresenceOnCreate = (event: IQuickstartGuideEvent) => {
-  if(!event.params.data.quickstartGuideItems || event.params.data.quickstartGuideItems!.connect!.length === 0){
+  const { quickstartGuideItems } = event.params.data;
+
+  if (!quickstartGuideItems?.connect?.length) {
     throw new errors.ApplicationError('QuickstartGuide must have at least one quickstart guide item');
   }
+
   return true;
-}
+};
 
 export const validateQuickstartGuideItemsPresenceOnUpdate = async (event: IQuickstartGuideEvent) => {
   const documentId = event.params.data.documentId || event.params.documentId;
+
   if (!documentId) {
     throw new errors.ApplicationError('QuickstartGuide documentId not found');
   }
+
   const foundQuickstartGuide = await strapi.db
     .query('api::quickstart-guide.quickstart-guide')
     .findOne({
-      where: {documentId},
+      where: { documentId },
       populate: ['quickstartGuideItems'],
     });
 
   if (!foundQuickstartGuide) {
     throw new errors.ApplicationError('QuickstartGuide not found');
   }
-  const quickstartGuideItemsDelta =event.params.data.quickstartGuideItems!.disconnect!.length - event.params.data.quickstartGuideItems!.connect!.length
 
-  if(event.params.data.quickstartGuideItems && event.params.data.quickstartGuideItems.disconnect!.length > 0) {
-    if (foundQuickstartGuide.quickstartGuideItems.length === 0 || foundQuickstartGuide.quickstartGuideItems.length <= quickstartGuideItemsDelta) {
-      throw new errors.ApplicationError('QuickstartGuide must have at least one quickstart guide item');
-    }
+  const items = event.params.data.quickstartGuideItems;
+  const connectLength = items?.connect?.length || 0;
+  const disconnectLength = items?.disconnect?.length || 0;
+  const currentLength = foundQuickstartGuide.quickstartGuideItems?.length || 0;
+
+  const newLength = currentLength - disconnectLength + connectLength;
+
+  if (newLength <= 0) {
+    throw new errors.ApplicationError('QuickstartGuide must have at least one quickstart guide item');
   }
-  else if(foundQuickstartGuide.quickstartGuideItems.length === 0 && quickstartGuideItemsDelta === 0) {throw new errors.ApplicationError('QuickstartGuide must have at least one quickstart guide item');
-  }
+
   return true;
-}
+};

--- a/apps/strapi-cms/src/utils/validateQuickstartGuide.ts
+++ b/apps/strapi-cms/src/utils/validateQuickstartGuide.ts
@@ -12,6 +12,7 @@ export interface IQuickstartGuideEvent {
     readonly documentId?: string;
     readonly locale?: string;
   };
+  readonly action?: string;
 }
 
 export interface IQuickstartGuideItemsEvent {
@@ -39,24 +40,23 @@ export const validateQuickstartGuideItemsPresenceOnUpdate = async (event: IQuick
     throw new errors.ApplicationError('QuickstartGuide documentId not found');
   }
 
-  const foundQuickstartGuide = await strapi.db
-    .query('api::quickstart-guide.quickstart-guide')
+  const quickstartGuide = await strapi
+    .documents('api::quickstart-guide.quickstart-guide')
     .findOne({
-      where: {
-        documentId,
-        ...(locale ? { locale } : {}),
-      },
+      documentId,
+      status: event.action === 'publish' ? 'draft' : 'published',
+      ...(locale ? { locale } : {}),
       populate: ['quickstartGuideItems'],
     });
 
-  if (!foundQuickstartGuide) {
+  if (!quickstartGuide) {
     throw new errors.ApplicationError('QuickstartGuide not found');
   }
 
   const items = event.params.data?.quickstartGuideItems;
   const connectLength = items?.connect?.length || 0;
   const disconnectLength = items?.disconnect?.length || 0;
-  const currentLength = foundQuickstartGuide.quickstartGuideItems?.length || 0;
+  const currentLength = quickstartGuide.quickstartGuideItems?.length || 0;
 
   const newLength = currentLength - disconnectLength + connectLength;
 

--- a/apps/strapi-cms/src/utils/validateQuickstartGuide.ts
+++ b/apps/strapi-cms/src/utils/validateQuickstartGuide.ts
@@ -1,0 +1,55 @@
+import {errors} from "@strapi/utils";
+
+export interface IQuickstartGuideEvent {
+  readonly params: {
+    readonly data: {
+      readonly documentId?: string;
+      readonly quickstartGuideItems?: {
+        readonly connect?: IQuickstartGuideItemsEvent[]
+        readonly disconnect?: IQuickstartGuideItemsEvent[]
+      }
+    }
+    readonly documentId?: string;
+  }
+}
+
+interface IQuickstartGuideItemsEvent {
+  readonly id?: string;
+  readonly documentId?: string;
+  readonly locale?: string;
+  readonly isTemporary?: boolean;
+}
+
+export const validateQuickstartGuideItemsPresenceOnCreate = (event: IQuickstartGuideEvent) => {
+  if(!event.params.data.quickstartGuideItems || event.params.data.quickstartGuideItems!.connect!.length === 0){
+    throw new errors.ApplicationError('QuickstartGuide must have at least one quickstart guide item');
+  }
+  return true;
+}
+
+export const validateQuickstartGuideItemsPresenceOnUpdate = async (event: IQuickstartGuideEvent) => {
+  const documentId = event.params.data.documentId || event.params.documentId;
+  if (!documentId) {
+    throw new errors.ApplicationError('QuickstartGuide documentId not found');
+  }
+  const foundQuickstartGuide = await strapi.db
+    .query('api::quickstart-guide.quickstart-guide')
+    .findOne({
+      where: {documentId},
+      populate: ['quickstartGuideItems'],
+    });
+
+  if (!foundQuickstartGuide) {
+    throw new errors.ApplicationError('QuickstartGuide not found');
+  }
+  const quickstartGuideItemsDelta =event.params.data.quickstartGuideItems!.disconnect!.length - event.params.data.quickstartGuideItems!.connect!.length
+
+  if(event.params.data.quickstartGuideItems && event.params.data.quickstartGuideItems.disconnect!.length > 0) {
+    if (foundQuickstartGuide.quickstartGuideItems.length === 0 || foundQuickstartGuide.quickstartGuideItems.length <= quickstartGuideItemsDelta) {
+      throw new errors.ApplicationError('QuickstartGuide must have at least one quickstart guide item');
+    }
+  }
+  else if(foundQuickstartGuide.quickstartGuideItems.length === 0 && quickstartGuideItemsDelta === 0) {throw new errors.ApplicationError('QuickstartGuide must have at least one quickstart guide item');
+  }
+  return true;
+}

--- a/apps/strapi-cms/src/utils/validateQuickstartGuide.ts
+++ b/apps/strapi-cms/src/utils/validateQuickstartGuide.ts
@@ -42,7 +42,10 @@ export const validateQuickstartGuideItemsPresenceOnUpdate = async (event: IQuick
   const foundQuickstartGuide = await strapi.db
     .query('api::quickstart-guide.quickstart-guide')
     .findOne({
-      where: { documentId },
+      where: {
+        documentId,
+        ...(locale ? { locale } : {}),
+      },
       populate: ['quickstartGuideItems'],
     });
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
This pull request adds validation logic to ensure that every `quickstart-guide` entry in the Strapi CMS always has at least one associated quickstart guide item. This helps prevent the creation or update of guides without any items, improving data integrity.

Validation for Quickstart Guide Items:

* Added two new validation functions, `validateQuickstartGuideItemsPresenceOnCreate` and `validateQuickstartGuideItemsPresenceOnUpdate`, in `validateQuickstartGuide.ts` to enforce that at least one quickstart guide item is present during creation and updates.
* Integrated these validation checks into the main Strapi CMS lifecycle in `index.ts`, applying them on the `create`, `update`, and `publish` actions for `quickstart-guide` entries. [[1]](diffhunk://#diff-29da7d11025410f98239f766dbf5fae8562b629a2dc4a9ed68d32ecb97b80ce8R18-R21) [[2]](diffhunk://#diff-29da7d11025410f98239f766dbf5fae8562b629a2dc4a9ed68d32ecb97b80ce8R85-R92)

Documentation:

* Added a changeset describing the addition of validation to the quickstart guide functionality.
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

