### PR TITLE
[DEV-4322] fix active campaign api call

### DIFF
--- a/.changeset/fluffy-files-drum.md
+++ b/.changeset/fluffy-files-drum.md
@@ -1,0 +1,5 @@
+---
+"strapi-cms": patch
+---
+
+Fix Active campaign api call when creating a webinar on strapi

--- a/apps/strapi-cms/src/utils/activeCampaignWebinar.ts
+++ b/apps/strapi-cms/src/utils/activeCampaignWebinar.ts
@@ -48,13 +48,13 @@ export const createActiveCampaignList = async (
 ): Promise<boolean> => {
   if (
     !getActiveCampaignIntegrationIsEnabled() ||
-    !event.result?.slug ||
-    !event.result?.title
+    !event.params.data?.slug ||
+    !event.params.data?.title
   ) {
     return true;
   }
 
-  const { slug: name, title: stringid } = event.result;
+  const { slug: name, title: stringid } = event.params.data;
 
   const payload: IActiveCampaignListPayload = {
     list: {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

This pull request fixes an issue with the ActiveCampaign API call when creating a webinar in Strapi. The update ensures that the correct data is used when sending information to ActiveCampaign.

Integration bug fix:

* Updated `createActiveCampaignList` in `activeCampaignWebinar.ts` to use `event.params.data` for `slug` and `title` instead of `event.result`, ensuring the correct values are sent to the ActiveCampaign API when creating a webinar.

Documentation:

* Added a changeset describing the patch fix for the ActiveCampaign API call when creating a webinar on Strapi.
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
